### PR TITLE
Refresh path after executing the Rust installer.

### DIFF
--- a/rustup.ps1
+++ b/rustup.ps1
@@ -63,8 +63,9 @@ echo "Downloads complete."
 # Install the rust binaries
 Start-Process $rust_installer -Wait
 
-# Refresh path for this process after installation (the Rust installer uses the system PATH, not user)
-$env:Path = [System.Environment]::GetEnvironmentVariable("Path", "Machine")
+# Refresh path for this process after installation
+$env:Path = [System.Environment]::GetEnvironmentVariable("Path", "User")
+$env:Path += ";" + [System.Environment]::GetEnvironmentVariable("Path", "Machine")
 
 # Looking for the dir which has rustc in it, which may fail if the user doesn't add rust\bin to
 # their path or for multiple rust versions


### PR DESCRIPTION
Allows the Cargo executable to be properly copied after installation if
the Rust bin folder was not previously in the user's path.

This will still fail if the user chooses to not add Rust to their path
during installation.  Perhaps a message box or similar should be
displayed prior the running the installer?
